### PR TITLE
去掉 redis-cluster timeout 参数

### DIFF
--- a/bin/install_redis_cluster.sh
+++ b/bin/install_redis_cluster.sh
@@ -130,7 +130,7 @@ cluster-announce-port ${PORT}
 cluster-announce-bus-port 1${PORT}
 bind ${BIND_ADDR}
 cluster-announce-ip ${BIND_ADDR}
-timeout 360
+#timeout 360
 loglevel notice
 logfile ${LOG_DIR}/${NAME}.log
 tcp-backlog 511


### PR DESCRIPTION
gse 某个依赖库不支持该参数